### PR TITLE
update deps to pull in backports.zoneinfo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,19 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - setuptools
     - pip
     - setuptools_scm
 
   run:
-    - python >=3.7
+    - python >=3.8
     - affine
-    - backports.zoneinfo
     - geopandas
     - google-api-python-client
     - jinja2
@@ -45,6 +44,8 @@ requirements:
     - scipy
     - shapely
     - sqlalchemy
+    # Sneeky way to get backports.zoneinfo
+    - tzlocal
     - xarray
 
 test:


### PR DESCRIPTION
hacky way attempting to pull in `backports.zoneinfo` and still maintain `noarch`
